### PR TITLE
Distinguish between fs types when mounting sdcards

### DIFF
--- a/scripts/mount-sd.sh
+++ b/scripts/mount-sd.sh
@@ -20,8 +20,10 @@ if [ "$ACTION" = "add" ]; then
 			mount $SDCARD $MNT -o uid=$DEF_UID,gid=$DEF_GID
 			;;
 		*)
-			mount $SDCARD $MNT
-			chown $DEF_UID:$DEF_GID $MNT
+			if [ ! -z "${ID_FS_TYPE}" ]; then
+				mount $SDCARD $MNT
+				chown $DEF_UID:$DEF_GID $MNT
+			fi
 			;;
 	esac
 else


### PR DESCRIPTION
Currently only vfat formatted sdcards will get mounted, when using other formats like ext4 or btrfs the mount will fail since  unsupported mount options are being passed (uid,gid).
