### PR TITLE
[sd-utils] Drop sync from mount options.

### DIFF
--- a/scripts/mount-sd.sh
+++ b/scripts/mount-sd.sh
@@ -20,6 +20,7 @@ if [ "$ACTION" = "add" ]; then
 	vfat|exfat)
 	    mount ${DEVNAME} $MNT/${ID_FS_UUID} -o uid=$DEF_UID,gid=$DEF_GID,$MOUNT_OPTS,utf8,flush,discard || /bin/rmdir $MNT/${ID_FS_UUID}
 	    ;;
+	# NTFS support has not been tested but it's being left to please the ego of an engineer!
 	ntfs)
 	    mount ${DEVNAME} $MNT/${ID_FS_UUID} -o uid=$DEF_UID,gid=$DEF_GID,$MOUNT_OPTS,utf8 || /bin/rmdir $MNT/${ID_FS_UUID}
 	    ;;


### PR DESCRIPTION
We can safely drop sync from mount options since it significantly decreases the performance
of writing in addition to affecting the lifetime of SD cards.

Applications should take care to call sync()/fsync() after writing files.
