### PR TITLE
Do not try to mount device node that isn't partition.

### DIFF
--- a/rules/90-mount-sd.rules
+++ b/rules/90-mount-sd.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", KERNEL=="mmcblk1*", ACTION=="add", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}="mount-sd@%k.service", ENV{SYSTEMD_USER_WANTS}="tracker-miner-fs.service tracker-store.service"
+SUBSYSTEM=="block", KERNEL=="mmcblk1*", ATTR{partition}!="", ACTION=="add", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}="mount-sd@%k.service", ENV{SYSTEMD_USER_WANTS}="tracker-miner-fs.service tracker-store.service"


### PR DESCRIPTION
[sd-utils] Do not try to mount device node that isn't partition. Fixes MER#914.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>