### PR TITLE
[mount-sd] Ensure media root dir is owned by the user : Fixes MB#1010

### DIFF
--- a/scripts/mount-sd.sh
+++ b/scripts/mount-sd.sh
@@ -58,6 +58,8 @@ if [ "$ACTION" = "add" ]; then
 	    ;;
 	*)
 	    mount ${DEVNAME} $MNT/${UUID} -o $MOUNT_OPTS || /bin/rmdir $MNT/${UUID}
+	    # Ensure the root dir of any linuxy SD is owned by the user
+	    chown $DEF_UID:$DEF_GID $MNT $MNT/${UUID}
 	    ;;
     esac
     test -d $MNT/${UUID} && touch $MNT/${UUID}


### PR DESCRIPTION
Ensure the root dir of any linuxy SD is owned by the user so they can, you know ... *write* to it :)