### PR TITLE
Patch to add support for swap space on SD card

### DIFF
--- a/rpm/sdcard-utils.spec
+++ b/rpm/sdcard-utils.spec
@@ -1,6 +1,6 @@
 Name:       sd-utils
 Summary:    SailfishOS scripts to mount/umount external sdcard.
-Version:    0.3
+Version:    0.4
 Release:    1
 Group:      System/Base
 License:    MIT
@@ -9,7 +9,8 @@ URL:        https://github.com/nemomobile/sd-utils/
 Source0:    %{name}-%{version}.tar.gz
 BuildRequires:  systemd
 Requires:   systemd
-Requires:   tracker
+# Required for lsblk
+Requires:   util-linux
 
 %description
 %{summary}

--- a/rules/90-mount-sd.rules
+++ b/rules/90-mount-sd.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="block", KERNEL=="mmcblk1*", ACTION=="add", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}="mount-sd@%k.service", ENV{SYSTEMD_USER_WANTS}="tracker-miner-fs.service tracker-store.service"
+SUBSYSTEM=="block", KERNEL=="mmcblk1*", ACTION=="add", MODE="0660", TAG+="systemd", ENV{SYSTEMD_WANTS}="mount-sd@%k.service"

--- a/scripts/mount-sd.sh
+++ b/scripts/mount-sd.sh
@@ -59,19 +59,6 @@ if [ "$ACTION" = "add" ]; then
         exit 0
     fi
 
-    # This hack is here to delay mounting the sdcard until tracker is ready
-    export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$DEF_UID/dbus/user_bus_socket
-    count=1
-    while true; do 
-        test $count -ge 64 && break
-        MINER_STATUS="$(dbus-send --type=method_call --print-reply --session --dest=org.freedesktop.Tracker1.Miner.Files /org/freedesktop/Tracker1/Miner/Files org.freedesktop.Tracker1.Miner.GetStatus | grep -o 'Idle')"
-        STORE_STATUS="$(dbus-send --type=method_call --print-reply --session --dest=org.freedesktop.Tracker1 /org/freedesktop/Tracker1/Status org.freedesktop.Tracker1.Status.GetStatus | grep -o 'Idle')"
-        test "$MINER_STATUS" = "Idle" -a "$STORE_STATUS" = "Idle" && break
-        systemd-cat -t mount-sd /bin/echo "Waiting $count seconds for tracker"
-        sleep $count ; 
-        count=$(( count + count ))
-    done
-
     test -d $MNT/${UUID} || mkdir -p $MNT/${UUID}
     chown $DEF_UID:$DEF_GID $MNT $MNT/${UUID}
     touch $MNT/${UUID}


### PR DESCRIPTION
NOTE: 'discard=once' currently not supported by Jolla, using 'discard' instead
priority set to 10 (i.e.: lower than zram)

At some point of time in the future, I should add support for options - e.g.: in /etc/sysconfig/mount-sd
