### PR TITLE
Fix mounting when UUID is not set.

### DIFF
--- a/rpm/sdcard-utils.spec
+++ b/rpm/sdcard-utils.spec
@@ -10,6 +10,8 @@ Source0:    %{name}-%{version}.tar.gz
 BuildRequires:  systemd
 Requires:   systemd
 Requires:   tracker
+# Required for lsblk
+Requires:   util-linux
 
 %description
 %{summary}


### PR DESCRIPTION
[sdcard] Fix mounting when UUID is not set. Fixes JB#31732.

Some sdcards do not have UUID set for partitions at the factory which
makes current way of mounting fail. This patch introduces use of CID
which is Card Identification and is quite unique.

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>